### PR TITLE
kdv integration tests

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.kubling</groupId>
         <artifactId>kubling-teiid</artifactId>
-        <version>24.2.1</version>
+        <version>24.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kubling</groupId>
         <artifactId>kubling-teiid</artifactId>
-        <version>24.2.1</version>
+        <version>24.2.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/src/main/java/com/kubling/teiid/client/lob/StreamingLobChunckProducer.java
+++ b/client/src/main/java/com/kubling/teiid/client/lob/StreamingLobChunckProducer.java
@@ -68,8 +68,7 @@ public class StreamingLobChunckProducer implements LobChunkProducer {
                     dqp.requestNextLobChunk(streamRequestId, requestId, streamable.getReferenceStreamId());
             return result.get();
         } catch (Exception e) {
-            IOException ex = new IOException(JDBCPlugin.Util.getString("StreamImpl.Unable_to_read_data_from_stream", e.getMessage())); //$NON-NLS-1$
-            ex.initCause(e);
+            IOException ex = new IOException(JDBCPlugin.Util.getString("StreamImpl.Unable_to_read_data_from_stream", e.getMessage()), e); //$NON-NLS-1$
             throw ex;
         }
     }

--- a/client/src/test/java/com/kubling/teiid/client/util/TestExceptionHolder.java
+++ b/client/src/test/java/com/kubling/teiid/client/util/TestExceptionHolder.java
@@ -122,13 +122,11 @@ public class TestExceptionHolder {
     @Test public void testSQLExceptionChain() throws Exception {
         ClassLoader cl = new URLClassLoader(new URL[] {UnitTestUtil.getTestDataFile("test.jar").toURI().toURL()});
         Exception obj = (Exception)ReflectionHelper.create("test.UnknownException", null, cl);
-        SQLException se = new SQLException("something bad happened");
-        se.initCause(obj);
+        SQLException se = new SQLException("something bad happened", obj);
 
         SQLException next = se;
         for (int i = 0; i < 10; i++) {
-            SQLException se1 = new SQLException("something else bad happened");
-            se1.initCause(obj);
+            SQLException se1 = new SQLException("something else bad happened", obj);
             next.setNextException(se1);
             next = se1;
         }

--- a/common-core/pom.xml
+++ b/common-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kubling</groupId>
         <artifactId>kubling-teiid</artifactId>
-        <version>24.2.1</version>
+        <version>24.2.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/common-core/src/main/java/com/kubling/teiid/core/types/BaseLob.java
+++ b/common-core/src/main/java/com/kubling/teiid/core/types/BaseLob.java
@@ -78,8 +78,7 @@ public class BaseLob implements Externalizable, StreamFactoryReference {
                 return r;
             }
         } catch (IOException e) {
-            SQLException ex = new SQLException(e.getMessage());
-            ex.initCause(e);
+            SQLException ex = new SQLException(e.getMessage(), e);
             throw ex;
         }
         Charset cs = getCharset();
@@ -93,8 +92,7 @@ public class BaseLob implements Externalizable, StreamFactoryReference {
         try {
             return this.getStreamFactory().getInputStream();
         } catch (IOException e) {
-            SQLException ex = new SQLException(e.getMessage());
-            ex.initCause(e);
+            SQLException ex = new SQLException(e.getMessage(), e);
             throw ex;
         }
     }

--- a/common-core/src/main/java/com/kubling/teiid/core/types/BlobImpl.java
+++ b/common-core/src/main/java/com/kubling/teiid/core/types/BlobImpl.java
@@ -86,7 +86,7 @@ public class BlobImpl extends BaseLob implements Blob, StreamProvider {
         }
         InputStream in = getBinaryStream();
         try {
-            long skipped = 0;
+            long skipped;
             while (pos > 0) {
                 skipped = in.skip(pos);
                 pos -= skipped;
@@ -206,6 +206,17 @@ public class BlobImpl extends BaseLob implements Blob, StreamProvider {
             return b.length();
         } catch (SQLException e) {
             return -1;
+        }
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return new String(getBinaryStream().readAllBytes());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/common-core/src/main/java/com/kubling/teiid/core/types/ClobImpl.java
+++ b/common-core/src/main/java/com/kubling/teiid/core/types/ClobImpl.java
@@ -244,4 +244,14 @@ public class ClobImpl extends BaseLob implements Clob {
         return new ClobImpl(chars);
     }
 
+    @Override
+    public String toString() {
+        try {
+            return new String(getAsciiStream().readAllBytes());
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/common-core/src/main/java/com/kubling/teiid/core/types/SQLXMLImpl.java
+++ b/common-core/src/main/java/com/kubling/teiid/core/types/SQLXMLImpl.java
@@ -142,9 +142,17 @@ public class SQLXMLImpl extends BaseLob implements SQLXML {
         try {
             return ObjectConverterUtil.convertToString(getCharacterStream());
         } catch (IOException e) {
-            SQLException ex = new SQLException(e.getMessage());
-            ex.initCause(e);
+            SQLException ex = new SQLException(e.getMessage(), e);
             throw ex;
+        }
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return getString();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/hibernate-dialect/pom.xml
+++ b/hibernate-dialect/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.kubling</groupId>
         <artifactId>kubling-teiid</artifactId>
-        <version>24.2.1</version>
+        <version>24.2.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kubling</groupId>
     <artifactId>kubling-teiid</artifactId>
-    <version>24.2.1</version>
+    <version>24.2.2</version>
     <packaging>pom</packaging>
 
     <description>The only free Virtual DB Engine for Operations.</description>


### PR DESCRIPTION
- Small change, added a required `toString()` for consuming in a JS test context.
- Removed deprecated `initCause` calls.